### PR TITLE
Updated 'React' import to be more verbose.

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import {View, Text, StyleSheet} from 'react-native';
+import { Component } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 
-export default class App extends React.Component {
+export default class App extends Component {
 
   render() {
       return (
@@ -21,4 +21,4 @@ const styles = StyleSheet.create({
   dummyText: {
     textAlign: 'center',
   }
-})
+});


### PR DESCRIPTION
#10 

React imports should explicitly import the module needed rather than the entire React class - e.g. Component.